### PR TITLE
Avoid invalid papersize.

### DIFF
--- a/pxjahyper.sty
+++ b/pxjahyper.sty
@@ -580,8 +580,10 @@ pxhy@fallback@geta = \ifpxhy@fallback@geta true\else false\fi^^J%
     \ifnum0<\mag \ifnum32768>\mag % \mag is in valid range
       \begingroup
         \@ifundefined{stockwidth}{}{%else
-          \paperwidth=\stockwidth
-          \paperheight=\stockheight
+          \ifdim\stockwidth>\z@ \ifdim\stockheight>\z@
+            \paperwidth=\stockwidth
+            \paperheight=\stockheight
+          \fi\fi
         }%
         \@tempcnta=\mag \advance\@tempcnta100000
         \def\pxhy@next1#1#2#3#4#5\relax{%
@@ -590,10 +592,12 @@ pxhy@fallback@geta = \ifpxhy@fallback@geta true\else false\fi^^J%
         \expandafter\pxhy@next\the\@tempcnta\relax
         \paperwidth=\pxhy@tmpa\paperwidth
         \paperheight=\pxhy@tmpa\paperheight
-        \edef\pxhy@tmpa{%
-          \noexpand\pxhy@begin@dvi@hook{%
-            \special{papersize=\the\paperwidth,\the\paperheight}}%
-        }\pxhy@tmpa
+        \ifdim\paperwidth>\z@ \ifdim\paperheight>\z@
+          \edef\pxhy@tmpa{%
+            \noexpand\pxhy@begin@dvi@hook{%
+              \special{papersize=\the\paperwidth,\the\paperheight}}%
+          }\pxhy@tmpa
+        \fi\fi
       \endgroup
     \fi\fi
   \fi


### PR DESCRIPTION
新しい hyperref 2022-09-22 v7.00t では `\stockwidth` および `\stockheight` が常に定義されるようになりました。
ただし、定義のみで値はセットされず（クラスファイル等がセットしない限り）0pt のままです。

PXjahyper では `\mag` が 1000 でない場合に適切に補正した papersize special を出力しています。
この時 `\stockwidth` が定義されていれば `\stockwidth` および `\stockheight` を使用するようになっているため、
これらが 0pt の場合 `papersize=0pt,0pt` が出力されてしまい不正がなサイズの PDF が作成されてしまいます。

これに対処するため `\stockwidth` および `\stockheight` がともに 0pt よりも大きいときのみこれらが使われるように修正しました。
また念のため `\paperwidth` および `\paperheight` にも同様のチェックを行いこれらが 0pt より大きくない場合は papersize special を出力しないようにしています。