### PR TITLE
Fix `Extra \fi` error when `^^ef` is the letter

### DIFF
--- a/pxjahyper.sty
+++ b/pxjahyper.sty
@@ -1085,7 +1085,7 @@ pxhy@fallback@geta = \ifpxhy@fallback@geta true\else false\fi^^J%
         pxhy@uhb/\string^^ef\endcsname^^ef}%
   }
   \xdef\pxhy@unprotect@high@bytes{%
-    \unexpanded{\ifx^^ef\pxhy@std@EF}%
+    \unexpanded{\ifx ^^ef\pxhy@std@EF}%
       \unexpanded\expandafter{\pxhy@unprotect@high@bytes}%
     \unexpanded{\fi}%
   }


### PR DESCRIPTION
hyperrefパッケージのunicodeオプションが有効で `^^ef` がcatcode 11 (letter)の状態でpxjahyperパッケージを読み込むと `Extra \fi` エラーが発生します。

```tex
%!uplatex
\documentclass{minimal}
\catcode`^^ef=11
\usepackage{hyperref}
\usepackage{pxjahyper}

```

```
! Extra \fi.
<argument> ...op@@ }\expandafter \@firstofone \fi
```

読み飛ばしされるコードの中の `\ifx^^ef` がifとして認識されないためにif-fiの対応関係が崩れてしまうようです。
`\ifx ^^ef` のようにスペースを入れることで直りました。